### PR TITLE
Create manifest.json

### DIFF
--- a/public/reports/manifest.json
+++ b/public/reports/manifest.json
@@ -1,0 +1,3 @@
+{
+	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+}


### PR DESCRIPTION
Add manifest.json to update CSP to resolve:

Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' *.google-analytics.com 'sha256-tSAfTBDI9GnqRGwSZkJvYTf662VRLJNAXe5ccqzpauw='". Either the 'unsafe-inline' keyword, a hash ('sha256-mvsAMOT/4lZBh+6zEhsa3CZ2VL0e1QDkjlne9LmO+P8='), or a nonce ('nonce-...') is required to enable inline execution.

Awaits Ed's approval @ Mozilla