### PR TITLE
adding accessible HTML version of web testing report

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -100,6 +100,9 @@
                 aspects of developing for the web: Testing across browsers.</p>
 
             <ul>
+              <li><a href="reports/mdn-web-testing-report-2021.html"
+                      class="button">View
+                      as HTML</a></li>
                 <li><a href="reports/pdf/MDN-Web-Testing-Report-2021.pdf"
                         class="button" target="_blank" rel="noopener noreferrer">Download
                         Report (PDF,


### PR DESCRIPTION
We had a request to create an accessible HTML version of the web testing report. I didn't have much time to spend on this, so I grabbed the HTML from the Google Doc version, and plugged the existing CSS into it. Needless to say, it is a bit scrappy, and not the prettiest, but it is accessible (I tested it, and there were few errors).

Does this look OK enough to put on the site?